### PR TITLE
Fixed: current might became invalid after ++it

### DIFF
--- a/include/transrangers.hpp
+++ b/include/transrangers.hpp
@@ -56,7 +56,14 @@ auto all(Range&& rng)
   return ranger<cursor>(
     [first=begin(rng),last=end(rng)](auto dst) TRANSRANGERS_HOT_MUTABLE {
     auto it=first;
-    while(it!=last)if(!dst(it++)){first=it;return false;}
+    while(it != last) {
+        if(!dst(it)) {
+            ++it;
+            first = it;
+            return false;
+        }
+        ++it;
+    }
     return true;
   });
 }


### PR DESCRIPTION
which leading to bad access in dst(current)

The fix: make sure `it` is first used, then `++`.

Another change: pre ++ is used instead of post ++, for `pre ++` is a must have while the other is optional? Some iterator didn't implement it.